### PR TITLE
Remove deprecated parameter from RectangleSelector calls

### DIFF
--- a/scripts/Image_Browser_Python.py
+++ b/scripts/Image_Browser_Python.py
@@ -1635,7 +1635,7 @@ class BEC1_Portal():
             self.display_image()
 
         toggle_selector.RS = RectangleSelector(self.ax, line_select_callback,
-        drawtype='box', useblit=True,
+        useblit=True,
         button=[1,3], # don't use middle button
         minspanx=5, minspany=5,
         spancoords='pixels')
@@ -2552,7 +2552,7 @@ class BEC1_Portal():
             self.display_image_live_analysis()
 
         toggle_selector.RS = RectangleSelector(self.ax_image_viewer_live_analysis, line_select_callback,
-        drawtype='box', useblit=True,
+        useblit=True,
         button=[1,3], # don't use middle button
         minspanx=5, minspany=5,
         spancoords='pixels')
@@ -2582,7 +2582,7 @@ class BEC1_Portal():
             self.display_image_live_analysis()
 
         toggle_selector.RS = RectangleSelector(self.ax_image_viewer_live_analysis, line_select_callback,
-        drawtype='box', useblit=True,
+        useblit=True,
         button=[1,3], # don't use middle button
         minspanx=5, minspany=5,
         spancoords='pixels')


### PR DESCRIPTION
Hotfix to make ImageBrowser compatible with new satyendra package versions